### PR TITLE
Always use SOCK snow cluster.

### DIFF
--- a/R/BME.R
+++ b/R/BME.R
@@ -73,7 +73,7 @@ BME <- function(Y, Z1, nIter = 1000L, burnIn = 300L, thin = 2L, bs = ceiling(dim
     class(out) <- 'BMECV'
 
   } else if (parallelCores > 1 && inherits(testingSet, 'CrossValidation')) {
-    cl <- snow::makeCluster(parallelCores)
+    cl <- snow::makeCluster(parallelCores, type="SOCK")
     doSNOW::registerDoSNOW(cl)
     nCV <- length(testingSet$CrossValidation_list)
 

--- a/R/BMORS.R
+++ b/R/BMORS.R
@@ -99,7 +99,7 @@ BMORS <- function(Y = NULL, ETA = NULL, covModel = 'BRR', predictor_Sec_complete
     out <- list(results = results, nIter = nIter, burnIn = burnIn, thin = thin, executionTime = proc.time()[3] - time.init)
     class(out) <- 'BMORSCV'
   } else if (parallelCores > 1 && inherits(testingSet, 'CrossValidation')) {
-    cl <- snow::makeCluster(parallelCores)
+    cl <- snow::makeCluster(parallelCores, type="SOCK")
     doSNOW::registerDoSNOW(cl)
     nCV <- length(testingSet$CrossValidation_list)
 

--- a/R/BMTME.R
+++ b/R/BMTME.R
@@ -83,7 +83,7 @@ BMTME <- function(Y, X, Z1, Z2, nIter = 1000L, burnIn = 300L, thin = 2L, bs = ce
     out <- list(results = results, n_cores = parallelCores, nIter = nIter, burnIn = burnIn, thin = thin, executionTime = proc.time()[3] - time.init)
     class(out) <- 'BMTMECV'
   } else if (parallelCores > 1 && inherits(testingSet, 'CrossValidation')) {
-    cl <- snow::makeCluster(parallelCores)
+    cl <- snow::makeCluster(parallelCores, type="SOCK")
     doSNOW::registerDoSNOW(cl)
     nCV <- length(testingSet$CrossValidation_list)
 


### PR DESCRIPTION
This fixes BMTME to explicitly specify snow cluster type (sock), which always works.

The default behavior of snow is to use MPI (when Rmpi package is installed), but then it is the responsibility of the user of snow, so in this case it would be of BMTME, to set up the cluster say using mpirun calls. Without that, on Windows with MSMPI and I hear on many other systems, BMTME fails. On Windows the error message is that "spawn" is not supported by the MPI implementation, which is the case of MSMPI and I hear that often spawn is disabled by administrators also on other systems.

The current behavior of BMTME on Windows is that it fails its checks (R CMD check) when Rmpi package is installed. This trivial patch fixes that problem.