### PR TITLE
Update DESCRIPTION to remove C++11 Sys Req

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,6 @@ LinkingTo:
     Rcpp,
     RcppArmadillo
 SystemRequirements:
-    C++11,
     GNU
 Suggests: 
     covr,


### PR DESCRIPTION
Fixes current CRAN NOTE so that it can be reininstated on CRAN with a new release. Does not interfere with @kalibera's PR.

See tidyverse.org/blog/2023/03/cran-checks-compiled-code for more on this change.